### PR TITLE
BOM-1563

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: python
 python:
 - 3.5
-- 3.6
+- 3.8
 env:
-- TOXENV=django111
-- TOXENV=django20
-- TOXENV=django21
 - TOXENV=django22
-matrix:
-  include:
-  - python: 3.6
-    env: TOXENV=quality
+- TOXENV=quality
 cache:
 - pip
 before_install:
-- pip install --upgrade pip
+- pip install pip==20.0.2
 install:
 - pip install -r requirements/travis.txt
 script:

--- a/setup.py
+++ b/setup.py
@@ -55,15 +55,12 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/splash/__init__.py
+++ b/splash/__init__.py
@@ -2,4 +2,4 @@
 Splash screen middleware for Django apps.
 """
 
-__version__ = '0.2.7'
+__version__ = '0.2.8'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-django{111},{py35,py36}-django{20,21,22}
+envlist = py35-django22, py38-django{22,30}
 
 [doc8]
 max-line-length = 120
@@ -15,10 +15,8 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     -r{toxinidir}/requirements/test.txt
 commands =
     python -Wd -m pytest {posargs}


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1563

stop testing Django versions prior to 2.2
start testing Python 3.8
remove py3.6 also.
Bump the version.