### PR TITLE
fix: Updated the upgrade-requirements job schedule

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,8 +2,8 @@ name: Upgrade Requirements
 
 on:
   schedule:
-    # will start the job at 06:00 UTC every Wednesday
-    - cron: "0 6 * * 3"
+    # will start the job at 01:45 UTC every Wednesday
+    - cron: "45 1 * * 3"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
Updated the upgrade-python-requirements job schedule as we need to run the jobs until 5:00 UTC